### PR TITLE
Unexpected exception OSError

### DIFF
--- a/src/pyrex/bison_.pyx
+++ b/src/pyrex/bison_.pyx
@@ -574,7 +574,8 @@ cdef class ParserEngine:
             if parser.verbose:
                 print 'rm %s' % f
 
-            os.unlink(f)
+            if os.path.isfile(f):
+                os.unlink(f)
 
     def closeLib(self):
         """


### PR DESCRIPTION
Problem: Unexpected exception OSError when deleting temporary files

``` python
 File "yerl_parser.py", line 141, in <module>
    p = Parser()
  File "../site-packages/bison/__init__.py", line 158, in __init__
    self.engine = ParserEngine(self)
  File "bison_.pyx", line 123, in bison_.ParserEngine.__init__
  File "bison_.pyx", line 141, in bison_.ParserEngine.openCurrentLib
  File "bison_.pyx", line 577, in bison_.ParserEngine.buildLib
OSError: [Errno 2] No such file or directory: 'tmp.tab.c'
```

Solution: Added checking 'os.path.isfile' before deletion
